### PR TITLE
Add support for category description for PunBB

### DIFF
--- a/lib/forum2discourse/importer.rb
+++ b/lib/forum2discourse/importer.rb
@@ -28,7 +28,7 @@ class Forum2Discourse::Importer
     log "Importing '#{topic.title}'"
     user = discourse_user(topic.posts.first.user)
     guardian = Guardian.new(user)
-    find_or_create_category(user, topic.category)
+    find_or_create_category(user, topic)
     discourse_topic = TopicCreator.new(user, guardian, topic.serialize).create
     import_topic_posts(discourse_topic, topic.posts)
   rescue
@@ -37,9 +37,12 @@ class Forum2Discourse::Importer
     puts $!.backtrace.join("\n")
   end
 
-  def find_or_create_category(user, category)
-    unless @categories.include? category
-      @categories << Category.create_with(user: user).find_or_create_by_name(category)
+  def find_or_create_category(user, topic)
+    unless @categories.include? topic.category
+      category = Category.create_with(user: user).find_or_create_by_name(topic.category)
+      category.update_attribute(:description, topic.category_desc)
+      puts category.inspect
+      @categories << category
     end
   end
 

--- a/lib/forum2discourse/importer.rb
+++ b/lib/forum2discourse/importer.rb
@@ -41,7 +41,6 @@ class Forum2Discourse::Importer
     unless @categories.include? topic.category
       category = Category.create_with(user: user).find_or_create_by_name(topic.category)
       category.update_attribute(:description, topic.category_desc)
-      puts category.inspect
       @categories << category
     end
   end

--- a/lib/forum2discourse/models/discourse/topic.rb
+++ b/lib/forum2discourse/models/discourse/topic.rb
@@ -1,6 +1,6 @@
 class Forum2Discourse::Models::Discourse::Topic < Forum2Discourse::Models::Discourse::Base
   # Standard attrs
-  attr_accessor :title, :category
+  attr_accessor :title, :category, :category_desc
 
   # User attrs
   attr_accessor :user_id, :last_post_user_id

--- a/lib/forum2discourse/models/punbb/topic.rb
+++ b/lib/forum2discourse/models/punbb/topic.rb
@@ -27,6 +27,7 @@ class Forum2Discourse::Models::PunBB::Topic
       title: subject,
       created_at: posted,
       category: forum.forum_name,
+      category_desc: forum.forum_desc,
       posts: posts.map(&:to_discourse)
     })
   end


### PR DESCRIPTION
This change adds a category description which depends on `forum_desc` field in PunBB database.
